### PR TITLE
Feat/expose to markdown

### DIFF
--- a/.changeset/cyan-cameras-begin.md
+++ b/.changeset/cyan-cameras-begin.md
@@ -1,0 +1,5 @@
+---
+"@puzzlet/templatedx": minor
+---
+
+Expose toMarkdown helper

--- a/src/element-plugin.ts
+++ b/src/element-plugin.ts
@@ -1,4 +1,4 @@
-import { Node } from "mdast";
+import { Node, Root } from "mdast";
 import type { Scope } from "./scope";
 import { NODE_TYPES } from "./constants";
 
@@ -7,11 +7,12 @@ interface NodeTypeHelpers {
   isMdxJsxFlowElement(node: Node): boolean;
   isMdxJsxTextElement(node: Node): boolean;
   isParentNode(node: Node): boolean;
+  toMarkdown(node: Root): string;
   NODE_TYPES: typeof NODE_TYPES;
 }
 
 export interface PluginContext {
-  nodeTypeHelpers: NodeTypeHelpers;
+  nodeHelpers: NodeTypeHelpers;
   createNodeTransformer: (scope: Scope) => any;
   scope: Scope;
   elementName: string;

--- a/src/element-plugins/for-each.ts
+++ b/src/element-plugins/for-each.ts
@@ -7,8 +7,8 @@ export class MapPlugin extends ElementPlugin {
     children: Node[],
     context: PluginContext
   ): Promise<Node[] | Node> {
-    const { scope, createNodeTransformer, nodeTypeHelpers } = context;
-    const { NODE_TYPES } = nodeTypeHelpers;
+    const { scope, createNodeTransformer, nodeHelpers } = context;
+    const { NODE_TYPES } = nodeHelpers;
     function areAllListItems(resultNodesPerItem: Node[][]): boolean {
       return resultNodesPerItem.every((processedNodes) =>
         processedNodes.every(

--- a/src/element-plugins/raw.ts
+++ b/src/element-plugins/raw.ts
@@ -1,23 +1,17 @@
 import { Node, Root } from "mdast";
-import { ElementPlugin } from "../element-plugin";
-import { toMarkdown, Options } from "mdast-util-to-markdown";
-import { mdxToMarkdown } from "mdast-util-mdx";
+import { ElementPlugin, PluginContext } from "../element-plugin";
 
 export class RawPlugin extends ElementPlugin {
   async transform(
     _props: Record<string, any>,
     children: Node[],
+    context: PluginContext
   ): Promise<Node[] | Node> {
-    const toMarkdownOptions: Options = {
-      extensions: [mdxToMarkdown()],
-    };
-    const rawContent = toMarkdown(
-      {
+    const { nodeHelpers } = context;
+    const rawContent = nodeHelpers.toMarkdown({
         type: 'root',
         children: children,
-      } as Root,
-      toMarkdownOptions
-    );
+    } as Root);
     return [
       {
         type: 'text',

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -23,14 +23,24 @@ import type {
   Parent, 
   RootContent,
 } from 'mdast';
+import { mdxToMarkdown } from "mdast-util-mdx";
+import { toMarkdown, Options } from 'mdast-util-to-markdown';
 
 jsep.plugins.register(jsepObject);
 
-const nodeTypeHelpers = {
+const options: Options = {
+  extensions: [mdxToMarkdown()],
+};
+const toMdxMarkdown = (node: Root) => {
+  return toMarkdown(node, options);
+}
+
+const nodeHelpers = {
   isMdxJsxElement,
   isMdxJsxFlowElement,
   isMdxJsxTextElement,
   isParentNode,
+  toMarkdown: toMdxMarkdown,
   NODE_TYPES,
 };
 
@@ -269,7 +279,7 @@ export class NodeTransformer {
           createNodeTransformer: (scope: Scope) => new NodeTransformer(scope),
           scope: this.scope,
           elementName,
-          nodeTypeHelpers,
+          nodeHelpers,
         };
         const result = await plugin.transform(props, node.children, pluginContext);
         return result;


### PR DESCRIPTION
## Description

Exposes `toMarkdown` to allow plugins to easily stringify.

Fixes # (issue)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
