### PR TITLE
fix: cannot require "fs/promises" dynamically

### DIFF
--- a/.changeset/thirty-shoes-search.md
+++ b/.changeset/thirty-shoes-search.md
@@ -1,0 +1,5 @@
+---
+"@puzzlet/templatedx": patch
+---
+
+use import instead of require

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const readFile = async (path: string) => {
     // @ts-ignore
     return await Deno.readTextFile(path);
   } else if (typeof require !== 'undefined') {
-    const { readFile } = require('fs/promises');
+    const { readFile } = await import('fs/promises');
     return await readFile(path, 'utf8');
   } else {
     throw new Error('Unsupported environment');


### PR DESCRIPTION
## Description
Error: Dynamic require of "fs/promises" is not supported

Fixes # (issue)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

tested inside a test project

## Checklist:

- [x] All new and existing tests passed.
